### PR TITLE
Added options for aspect ratio

### DIFF
--- a/ProtocolsforcommunicationbyMakers.tex
+++ b/ProtocolsforcommunicationbyMakers.tex
@@ -1,4 +1,10 @@
-\documentclass{beamer}
+% Developers Conference 2018
+% Beamer frames by Pritvi Jheengut
+
+% Change aspect ratio according to projector requirements
+% Options can be 169 (e.g for 16:9 aspect ratio), 149, 54, 43 and 32.
+\documentclass[aspectratio=169]{beamer}
+
 
 % package hyperref needs these to be set here
 


### PR DESCRIPTION
If not specified, beamer defaults to aspect ratio 4:3, i.e 128mm by 96mm.